### PR TITLE
Add server-side session management with Flask-Session.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ cython_debug/
 # Django stuff:
 
 # Flask stuff:
+flask_session/
 
 # Scrapy stuff:
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_session import Session
 from config import Config
 from flask_login import LoginManager
 from flask_migrate import Migrate
@@ -7,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()
 migrate = Migrate()
 login = LoginManager()
+sess = Session()
 login.login_view = "auth.login"  # View function that handles the login
 login.login_message = "Please login to access this page."
 
@@ -14,11 +16,16 @@ login.login_message = "Please login to access this page."
 def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
+    # TODO: Maybe refactor setting SESSION_TYPE to Config class.
+    # TODO: Change SESSION_TYPE to 'redis' when we have our Redis instance up and running.
+    # app.config['SESSION_TYPE'] = 'redis'
+    app.config['SESSION_TYPE'] = 'filesystem'
 
     # Initialize the Flask extensions.
     db.init_app(app)
     migrate.init_app(app, db)
     login.init_app(app)
+    sess.init_app(app)
 
     # Main blueprint.
     from app.main import bp as main_bp

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,5 @@
 import requests
-from flask import render_template
+from flask import render_template, session
 from flask_login import login_required, current_user
 from app import db
 from app.main import bp
@@ -7,9 +7,9 @@ from app.main.forms import GenerateSlangForm, MeaningForm
 from app.models import Slang
 
 
-@login_required
 @bp.route("/", methods=["GET", "POST"])
 @bp.route("/index", methods=["GET", "POST"])
+@login_required
 def index():
     generate_slang_form = GenerateSlangForm()
     meaning_form = MeaningForm()
@@ -56,3 +56,16 @@ def index():
         slang_word="", 
         **kwargs
         )
+
+
+@bp.route("/set/")
+def set():
+    """Route to test setting a value in session management."""
+    session['key'] = 'value'
+    return 'ok'
+
+
+@bp.route("/get")
+def get():
+    """Route to test getting a value in session management."""
+    return session.get('key', 'not set')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.6.5
+cachelib==0.2.0
 certifi==2021.5.30
 chardet==4.0.0
 click==8.0.1
@@ -8,6 +9,7 @@ email-validator==1.1.3
 Flask==2.0.1
 Flask-Login==0.5.0
 Flask-Migrate==3.0.1
+Flask-Session==0.4.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.15.1
 greenlet==1.1.0
@@ -18,6 +20,7 @@ Jinja2==3.0.1
 Mako==1.1.4
 MarkupSafe==2.0.1
 numpy==1.19.5
+pkg-resources==0.0.0
 psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 python-dotenv==0.18.0
@@ -25,7 +28,7 @@ python-editor==1.0.4
 requests==2.25.1
 six==1.16.0
 SQLAlchemy==1.4.20
-pytorch==1.8.0
+torch==1.9.0
 typing-extensions==3.10.0.0
 urllib3==1.26.6
 Werkzeug==2.0.1


### PR DESCRIPTION
Adding server-side session management with Flask-Session.
Two important benefits
* I can use this to store the most recently generated word, which makes it easier to persist this to the database.
* We can use this later on for session management for ML models, such that we don't have to reload them all the time.

Currently the session stores its required files in a flask_session folder which is personal, so no point in committing them to git, hence the update to the .gitignore. Once Redis is also up and running, we can switch the SESSION_TYPE from 'filesystem' to 'redis'.

Moreover I added an @login_required decorator to the index. This is because we currently have functionality in the /index route that assumes a current_user is logged in and available to be used for the user_id. Once we refactor this to something like a more specialized slang/meaning route, we can remove that.

Additions:
@annaproxy : Since I've updated the requirements.txt, could you do the same for the environment.yml and see if it works?Thanks.
PS. It also appears that I updated torch to the latest version.