### PR TITLE
Run black linter for full project.

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -55,7 +55,7 @@ def index():
         db.session.add(word_and_meaning)
         db.session.commit()
 
-        del session['slang_word']
+        del session["slang_word"]
 
         return render_template(
             "index.html",

--- a/app/ml_models/rnn/vocabulary.py
+++ b/app/ml_models/rnn/vocabulary.py
@@ -5,7 +5,7 @@ class Vocabulary:
     def build(
         self,
         prefix: str = "../../../data/",
-        filename_source: str = "dutch.txt", # TODO also fread from multiple files if necessary
+        filename_source: str = "dutch.txt",  # TODO also fread from multiple files if necessary
         filename_destination: str = "dutch_vocab.txt",
         overwrite: bool = False,
         lower: bool = True,

--- a/app/users/routes.py
+++ b/app/users/routes.py
@@ -25,6 +25,7 @@ def users(username):
 
     return render_template("users/user.html", user=user, words=words.items)
 
+
 # articles = (
 #     Article.query.filter_by(newspaper=newspaper)
 #     .order_by(Article.published_date.desc().nullslast())


### PR DESCRIPTION
Implements:
* Run black linter for the whole project.

Findings:
* isort is really tricky in a Flask project due to the following reasons:
  * Sometimes certain imports must be done after other ones or at least not at the top of the file.
  * Occasionally (rather, often), wrongly placed imports may lead to circular imports, causing the app to error out.
  * I'm not sure if there's an approved way to do this in flask projects.
  * Moreover, make sure to exclude your virtual environment from the isort run, because some modules in here can also error out due to wrongly placed imports.
* pydocstyle showed that there's still a lot of docstrings to be added (particularly to a lot of routes which I will try to work on. Also see this PR: https://github.com/Sasafrass/straattaal/pull/48 Any help is much appreciated.