### PR TITLE
Implement internal call so we can load model from session.

### DIFF
--- a/app/api/slang.py
+++ b/app/api/slang.py
@@ -20,22 +20,29 @@ def generate_slang():
 def generate_slang_internal():
     """Implement internal call to generate and return a new slang word instead of API call."""
     # Retrieve model from the session if it's already stored there.
-    if not (session.get("model", None) and session.get("vocab", None)):
+    if not (
+        session.get("model", None)
+        and session.get("vocab", None)
+        and session.get("dataset", None)
+    ):
         print("Model isn't stored in session! Loading...")
         model, vocab = load_model()
         session["model"] = model
         session["vocab"] = vocab
+
+        # Load both "existing" Dutch words and straattaal words to check
+        existing = WordLevelDataset(
+            prefix="data",
+            filename_datasets=["straattaal.txt", "dutch.txt"],
+            vocabulary=vocab,
+        ).all_words_to_set()
+        session["dataset"] = existing
     else:
         print("Retrieving model from the session...")
         model = session["model"]
         vocab = session["vocab"]
+        existing = session["dataset"]
 
-    # Load both "existing" Dutch words and straattaal words to check
-    existing = WordLevelDataset(
-        prefix="data",
-        filename_datasets=["straattaal.txt", "dutch.txt"],
-        vocabulary=vocab,
-    ).all_words_to_set()
     found_one = False
     max_words = 10
 

--- a/app/api/slang.py
+++ b/app/api/slang.py
@@ -10,7 +10,6 @@ from app.ml_models.rnn.generate import generate_word
 @bp.route("/generate_slang", methods=["GET"])
 def generate_slang():
     """Generate and return a new slang word."""
-
     # Return a json containing the newly generated word.
     new_word = generate_slang_internal()
     ret = jsonify(slang_word=new_word)
@@ -20,7 +19,6 @@ def generate_slang():
 
 def generate_slang_internal():
     """Implement internal call to generate and return a new slang word instead of API call."""
-
     # Retrieve model from the session if it's already stored there.
     if not (session.get("model", None) and session.get("vocab", None)):
         print("Model isn't stored in session! Loading...")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,8 +1,9 @@
 """Module containing all the routes for the main blueprint."""
-import requests
+# import requests
 from flask import flash, redirect, render_template, session, url_for
 from flask_login import login_required, current_user
 from app import db
+from app.api.slang import generate_slang_internal
 from app.main import bp
 from app.main.forms import GenerateSlangForm, MeaningForm
 from app.models import Slang
@@ -24,10 +25,11 @@ def index():
     }
 
     if generate_slang_form.submit_generate.data and generate_slang_form.validate():
-        # TODO: Might be overkill to use an API call here rather than internal call.
-        response = requests.get("http://localhost:5000/api/generate_slang")
-        response = response.json()
-        slang_word = response["slang_word"]
+        # # TODO: Might be overkill to use an API call here rather than internal call.
+        # response = requests.get("http://localhost:5000/api/generate_slang")
+        # response = response.json()
+        # slang_word = response["slang_word"]
+        slang_word = generate_slang_internal()
 
         # Set slang word in meaning_form for visual purposes and in session for retrieval.
         meaning_form.word.data = slang_word


### PR DESCRIPTION
This PR refactors the call to the /api/generate_slang route to retrieve a prediction and instead now makes use of an internal function call. This fixes the following issue (https://github.com/Sasafrass/straattaal/issues/21), and now the model and vocab do not reload for every new prediction.